### PR TITLE
Make ONE configurable from outside

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 scratch*
+one_config.json
 params_secret.py
 one_ibl/docs/_*
 one_ibl/__pycache__/*

--- a/one_config_template.json
+++ b/one_config_template.json
@@ -1,0 +1,4 @@
+{
+  "ALYX_PWD": "Password for Alyx",
+  "HTTP_DATA_SERVER_PWD":"Password for data server"
+}

--- a/one_ibl/params.py
+++ b/one_ibl/params.py
@@ -1,4 +1,14 @@
-import one_ibl.params_secret as sec
+try:
+    import one_ibl.params_secret as sec
+except:
+    import json
+    class DictWrapper(dict):
+        def __getattr__(self, attr):
+            return self[attr]
+
+    with open('one_config.json', 'r') as f:
+        sec = DictWrapper(json.load(f))
+
 # import one_ibl.params as par
 
 # BASE_URL = "https://alyx.cortexlab.net"


### PR DESCRIPTION
You can now configure ONE by having a `one_config.json` in the current directory when you import `one`.